### PR TITLE
fix: raspberry pi 32bit build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           - { target: aarch64-linux-musl, os: ubuntu-latest, strip: "llvm-strip", upx: "upx --lzma",
               cmake: "-DUSE_SYSTEM_PCAP=OFF" }
           - { target: arm-linux-musleabi, os: ubuntu-latest, strip: "llvm-strip", upx: "upx --lzma",
-              cmake: "-DUSE_SYSTEM_PCAP=OFF -DZIG_COMPILE_OPTION='-mcpu=cortex_a9'", name: "(cortex_a9)" }
+              cmake: "-DUSE_SYSTEM_PCAP=OFF -DZIG_COMPILE_OPTION='-mcpu=cortex_a7'", name: "(cortex_a7)" }
           - { target: arm-linux-musleabi, os: ubuntu-latest, strip: "llvm-strip", upx: "upx --lzma",
               cmake: "-DUSE_SYSTEM_PCAP=OFF -DZIG_COMPILE_OPTION='-mcpu=arm1176jzf_s'", name: "(pi_zero_w)" }
           - { target: mipsel-linux-musl,  os: ubuntu-latest, strip: "llvm-strip", upx: "upx --lzma",

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ cmake --build build pppwn
 cmake -B build -DZIG_TARGET=mipsel-linux-musl -DUSE_SYSTEM_PCAP=OFF -DZIG_COMPILE_OPTION="-msoft-float"
 cmake --build build pppwn
 
-# cross compile for arm linux (armv7 cortex-a9)
-cmake -B build -DZIG_TARGET=arm-linux-musleabi -DUSE_SYSTEM_PCAP=OFF -DZIG_COMPILE_OPTION="-mcpu=cortex_a9"
+# cross compile for arm linux (armv7 cortex-a7)
+cmake -B build -DZIG_TARGET=arm-linux-musleabi -DUSE_SYSTEM_PCAP=OFF -DZIG_COMPILE_OPTION="-mcpu=cortex_a7"
 cmake --build build pppwn
 
 # cross compile for Windows


### PR DESCRIPTION
Hello!

I created this PR to fix builds for 32-bit arm cpus.

According to the raspberrypi official website, the 32-bit arm soc has Cortex A7 cores, not A9.

https://www.raspberrypi.com/documentation/computers/processors.html
