### PR TITLE
Add a shortcut for the interface option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
     bool retry = false;
 
     auto cli = (
-            ("network interface" % required("--interface") & value("interface", interface), \
+            ("network interface" % required("-i", "--interface") & value("interface", interface), \
             SUPPORTED_FIRMWARE % option("--fw") & integer("fw", fw), \
             "stage1 binary" % option("--stage1") & value("STAGE1", stage1), \
             "stage2 binary" % option("--stage2") & value("STAGE2", stage2), \


### PR DESCRIPTION
Just a small QoL addition. I think it will be easier for those who use it manually. Since fw select and stage path options are optional and have defaults, it is quicker to write
`sudo ./pppwn -i eth0`
than
`sudo ./pppwn --interface eth0`.