### PR TITLE
Fix building on freebsd

### DIFF
--- a/src/gateway.cpp
+++ b/src/gateway.cpp
@@ -6,6 +6,7 @@
 #else
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #endif
 
 #include <IPv4Layer.h>


### PR DESCRIPTION
Fix for this error:
error: use of undeclared identifier 'INADDR_ANY'
addr.sin_addr.s_addr = htonl(INADDR_ANY);

Fixes building on FreeBSD, and doesnt break building on Linux.

Including netinet/in.h brings INADDR_ANY definition.